### PR TITLE
Add missing rsyslog modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ FROM alpine:latest
 RUN apk update \
     && apk add \
         rsyslog \
+        rsyslog-mmutf8fix \
+        rsyslog-mmjsonparse \
         supervisor \
         unzip
 COPY rsyslog.conf /etc/rsyslog.conf


### PR DESCRIPTION
I think mmutf8fix and mmjsonparse are not available under /usr/lib/rsyslog.

Noticed these kind of errors coming from the container syslog:

```
could not load module 'mmjsonparse', errors: trying to load module /usr/lib/rsyslog/mmjsonparse.so: Error loading shared library /usr/lib/rsyslog/mmjsonparse.so: No such file or directory
````